### PR TITLE
Add some basic Symfony debug tools to allow for more sensible debugging.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "ext-zip": "*",
     "symfony/dotenv": "^4.2@dev",
     "nanosoup/nemesis": "dev-master",
+    "nanosoup/erebus": "dev-master",
     "twig/twig": "2.x-dev",
     "wp-cli/wp-cli": "^2.0@dev",
     "wp-cli/core-command": "^2.0@dev",
@@ -45,5 +46,10 @@
       "@create-wordpress-db",
       "@install-wordpress-db"
     ]
+  },
+  "extra": {
+    "installer-paths": {
+      "wp-content/themes/{$name}": ["nanosoup/erebus"]
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,9 @@
     "wp-cli/db-command": "^2.0@dev"
   },
   "require-dev": {
-    "roave/security-advisories": "dev-master"
+    "roave/security-advisories": "dev-master",
+    "symfony/var-dumper": "^4.2@dev",
+    "symfony/debug": "^4.2@dev"
   },
   "scripts": {
     "install-wordpress": "wp core download --locale=en_GB --skip-content --force",

--- a/wp-config.php
+++ b/wp-config.php
@@ -4,6 +4,13 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require __DIR__.'/vendor/autoload.php';
 
+/**
+ * If we are in DEBUG mode, enable symfony debug component
+ */
+if (filter_var(getenv('WP_DEBUG'), FILTER_VALIDATE_BOOLEAN) === true) {
+    \Symfony\Component\Debug\Debug::enable();
+}
+
 $env = new Dotenv();
 $env->load(__DIR__.'/.env');
 


### PR DESCRIPTION
Include some basic debug classes for WP_DEBUG mode in Wordpress.